### PR TITLE
Fixed IntersectionGroup always resolving to NobodyGroup

### DIFF
--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/groups/IntersectionGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/groups/IntersectionGroup.java
@@ -54,7 +54,8 @@ public final class IntersectionGroup extends Group {
     }
 
     public static Group of(Stream<Group> groups) {
-        return groups.reduce(NobodyGroup.get(), (result, group) -> result.and(group));
+        return groups.findAny().isPresent() ? groups.reduce(AnyoneGroup.get(), (result, group) -> result.and(group)) : NobodyGroup
+                .get();
     }
 
     @Override


### PR DESCRIPTION
Resolve intersection of groups with AnyoneGroup as the initial condition, as long as the list of groups is empty. Previously any intersection would always resolve to NobodyGroup. Closes #159
