### PR TITLE
With toolkit

### DIFF
--- a/bennu-portal/src/main/webapp/bennu-toolkit/js/datepicker.js
+++ b/bennu-portal/src/main/webapp/bennu-toolkit/js/datepicker.js
@@ -925,7 +925,7 @@
                 getTemplate = function () {
                     if (picker.options.pickDate && picker.options.pickTime) {
                         var ret = '';
-                        ret = '<div class="bootstrap-datetimepicker-widget' + (picker.options.sideBySide ? ' timepicker-sbs' : '') + ' dropdown-menu" style="z-index:9999 !important;">';
+                        ret = '<div class="bootstrap-datetimepicker-widget' + (picker.options.sideBySide ? ' timepicker-sbs' : '') + ' dropdown-menu">';
                         if (picker.options.sideBySide) {
                             ret += '<div class="row">' +
                                 '<div class="col-sm-6 datepicker">' + dpGlobal.template + '</div>' +


### PR DESCRIPTION
Removed the explicit style definition in datepicker.js so it wont override bootstrap-datetimepicker-widget's z-index which is greater than this. This allows the datetimepicker to be seen when  used inside a modal. 
