### PR TITLE
Added filters to prevent CSRF attacks for POST/PUT/DELETE requests

### DIFF
--- a/bennu-spring/src/main/java/org/fenixedu/bennu/spring/BennuSpringConfiguration.java
+++ b/bennu-spring/src/main/java/org/fenixedu/bennu/spring/BennuSpringConfiguration.java
@@ -37,6 +37,8 @@ import org.fenixedu.bennu.spring.portal.PortalHandlerInterceptor;
 import org.fenixedu.bennu.spring.portal.PortalHandlerMapping;
 import org.fenixedu.bennu.spring.resolvers.AuthenticatedUserArgumentResolver;
 import org.fenixedu.bennu.spring.resolvers.BennuSpringExceptionResolver;
+import org.fenixedu.bennu.spring.security.CSRFInterceptor;
+import org.fenixedu.bennu.spring.security.CSRFTokenRepository;
 import org.fenixedu.commons.i18n.I18N;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +49,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -85,6 +88,7 @@ public class BennuSpringConfiguration extends WebMvcConfigurationSupport impleme
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new CSRFInterceptor(csrfTokenRepository()));
         registry.addInterceptor(new PortalHandlerInterceptor());
     }
 
@@ -107,6 +111,12 @@ public class BennuSpringConfiguration extends WebMvcConfigurationSupport impleme
         // to have an interface without a proper label, than one that doesn't work at all
         source.setUseCodeAsDefaultMessage(true);
         return source;
+    }
+
+    @Bean
+    @Order
+    public CSRFTokenRepository csrfTokenRepository() {
+        return new CSRFTokenRepository();
     }
 
     private Set<String> getBaseNames(ApplicationContext context) {

--- a/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFInterceptor.java
+++ b/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFInterceptor.java
@@ -1,0 +1,86 @@
+package org.fenixedu.bennu.spring.security;
+
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.fenixedu.bennu.core.security.SkipCSRF;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+
+/**
+ * Interceptor to prevent CSRF attacks on POST, PUT and DELETE methods.
+ * 
+ * Individual controller methods may choose to bypass this verification by annotating the method with {@link SkipCSRF}.
+ * 
+ * It will check that any request in the matching conditions contains a {@link CSRFToken} associated with it, either by providing
+ * a request parameter or header. A token may be obtained via the {@link CSRFTokenRepository#getToken(HttpServletRequest)} method.
+ * 
+ * @author João Carvalho (joao.pedro.carvalho@tecnico.ulisboa.pt)
+ * 
+ * @see CSRFToken
+ * @see CSRFTokenRepository
+ *
+ */
+public class CSRFInterceptor implements HandlerInterceptor {
+
+    private static final Set<String> METHODS_TO_FILTER = ImmutableSet.of("post", "put", "delete");
+
+    private final CSRFTokenRepository tokenRepository;
+
+    public CSRFInterceptor(CSRFTokenRepository tokenBean) {
+        this.tokenRepository = tokenBean;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        // Checks if the request is in conditions to check for CSRF token
+        if (METHODS_TO_FILTER.contains(request.getMethod().toLowerCase()) && shouldValidateCSRFToken(handler)) {
+            // Acquire the expected and the provided token...
+            CSRFToken token = tokenRepository.getToken(request);
+            String tokenValue = findToken(token, request);
+            // ... and compare them
+            if (Strings.isNullOrEmpty(tokenValue) || !tokenValue.equals(token.getToken())) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "CSRF Token not present or incorrect!");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Determines if the given method should be validated for a CSRF Token.
+     */
+    private boolean shouldValidateCSRFToken(Object handler) {
+        return !((HandlerMethod) handler).getMethod().isAnnotationPresent(SkipCSRF.class);
+    }
+
+    /*
+     * Retrieving the token provided by the user, either via header or parameter.
+     */
+    private String findToken(CSRFToken token, HttpServletRequest request) {
+        String value = request.getParameter(token.getParameterName());
+        if (Strings.isNullOrEmpty(value)) {
+            value = request.getHeader(token.getHeaderName());
+        }
+        return value;
+    }
+
+    @Override
+    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView)
+            throws Exception {
+        // Nothing to do here
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
+        // Nothing to do here
+    }
+
+}

--- a/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFToken.java
+++ b/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFToken.java
@@ -1,0 +1,77 @@
+package org.fenixedu.bennu.spring.security;
+
+import java.io.Serializable;
+
+/**
+ * Representation of a token that is used to prevent CSRF attacks.
+ * 
+ * @author João Carvalho (joao.pedro.carvalho@tecnico.ulisboa.pt)
+ */
+public class CSRFToken implements Serializable {
+
+    private static final long serialVersionUID = -7758859776587994878L;
+
+    private static final String DEFAULT_HEADER_NAME = "X-CSRF-TOKEN";
+    private static final String DEFAULT_PARAMETER_NAME = "_csrf";
+
+    private final String headerName;
+    private final String parameterName;
+    private final String token;
+
+    /**
+     * Constructs a new token with the given value, and default values for both {@code headerName} and {@code parameterName}.
+     * 
+     * @param token
+     *            The value of newly created token
+     */
+    public CSRFToken(String token) {
+        this(DEFAULT_HEADER_NAME, DEFAULT_PARAMETER_NAME, token);
+    }
+
+    /**
+     * Constructs a new token with the given Header Name, Parameter Name and Value.
+     * 
+     * @param headerName
+     *            The name of the header that is expected to contain the CSRF token
+     * @param parameterName
+     *            The name of the form parameter that is expected to contain the CSRF token
+     * @param token
+     *            The value of newly created token
+     */
+    public CSRFToken(String headerName, String parameterName, String token) {
+        this.headerName = headerName;
+        this.parameterName = parameterName;
+        this.token = token;
+    }
+
+    /**
+     * Returns the name of the header that is expected to contain the CSRF token.
+     * 
+     * @return
+     *         The CSRF Token header name
+     */
+    public String getHeaderName() {
+        return headerName;
+    }
+
+    /**
+     * Returns the name of the form parameter that is expected to contain the CSRF token.
+     * 
+     * @return
+     *         The CSRF Token parameter name
+     */
+    public String getParameterName() {
+        return parameterName;
+    }
+
+    /**
+     * Returns the value of this token.
+     * 
+     * @return
+     *         A string containing the value of this token
+     */
+    public String getToken() {
+        return token;
+    }
+
+}

--- a/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFTokenBean.java
+++ b/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFTokenBean.java
@@ -1,0 +1,85 @@
+package org.fenixedu.bennu.spring.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Utility class to provide easy access to {@link CSRFToken} in JSP contexts.
+ * 
+ * @author João Carvalho (joao.pedro.carvalho@tecnico.ulisboa.pt)
+ *
+ */
+@Component("csrf")
+public class CSRFTokenBean {
+
+    private final CSRFTokenRepository tokenRepository;
+
+    @Autowired
+    public CSRFTokenBean(CSRFTokenRepository tokenRepository) {
+        this.tokenRepository = tokenRepository;
+    }
+
+    /**
+     * Returns the value of the token associated with the current request.
+     * 
+     * @return
+     *         The token associated with this request
+     * @throws IllegalStateException
+     *             If this method is invoked outside a Spring MVC context
+     */
+    public String getToken() {
+        return tokenRepository.getToken(getCurrentRequest()).getToken();
+    }
+
+    /**
+     * Prints a HTML input field with the CSRF Token associated with the current request.
+     * 
+     * This allows simply adding
+     * 
+     * <pre>
+     * ${csrf.field()}
+     * </pre>
+     * 
+     * to any form to handle CSRF protection.
+     * 
+     * @return
+     *         An input field with the CSRF Token.
+     *
+     */
+    public String field() {
+        CSRFToken token = tokenRepository.getToken(getCurrentRequest());
+        return "<input type=\"hidden\" name=\"" + token.getParameterName() + "\" value=\"" + token.getToken() + "\"/>";
+    }
+
+    /**
+     * Returns the name of the form parameter that is expected to contain the CSRF token.
+     * 
+     * @return
+     *         The CSRF Token parameter name
+     */
+    public String getParameterName() {
+        return tokenRepository.getToken(getCurrentRequest()).getParameterName();
+    }
+
+    /**
+     * Returns the name of the header that is expected to contain the CSRF token.
+     * 
+     * This is particularly useful when invoking Spring-based REST endpoints.
+     * 
+     * @return
+     *         The CSRF Token header name
+     */
+    public String getHeaderName() {
+        return tokenRepository.getToken(getCurrentRequest()).getHeaderName();
+    }
+
+    private static HttpServletRequest getCurrentRequest() {
+        ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+        return attributes.getRequest();
+    }
+
+}

--- a/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFTokenRepository.java
+++ b/bennu-spring/src/main/java/org/fenixedu/bennu/spring/security/CSRFTokenRepository.java
@@ -1,0 +1,59 @@
+package org.fenixedu.bennu.spring.security;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+/**
+ * Repository responsible for the handling of {@link CSRFToken}s.
+ * 
+ * @author João Carvalho (joao.pedro.carvalho@tecnico.ulisboa.pt)
+ *
+ */
+public class CSRFTokenRepository {
+
+    private static final String CSRF_TOKEN_ATTRIBUTE = CSRFTokenRepository.class.getName() + ".CSRF_TOKEN";
+
+    private final SecureRandom random = new SecureRandom();
+
+    /**
+     * Returns the {@link CSRFToken} associated with the given request.
+     * 
+     * The default implementation stores the token itself in the {@link HttpSession}, generating a new one, if no token is
+     * currently associated.
+     * 
+     * @param request
+     *            The request for which to return the token
+     * @return
+     *         The token associated with the given request
+     */
+    public CSRFToken getToken(HttpServletRequest request) {
+        HttpSession session = request.getSession();
+        CSRFToken token = (CSRFToken) session.getAttribute(CSRF_TOKEN_ATTRIBUTE);
+        if (token == null) {
+            synchronized (session) {
+                token = (CSRFToken) session.getAttribute(CSRF_TOKEN_ATTRIBUTE);
+                if (token == null) {
+                    token = generateNewToken();
+                    session.setAttribute(CSRF_TOKEN_ATTRIBUTE, token);
+                }
+            }
+        }
+        return token;
+    }
+
+    /**
+     * Generates a new {@link CSRFToken}.
+     * 
+     * @return
+     *         A new, randomly-generated {@link CSRFToken}
+     */
+    protected CSRFToken generateNewToken() {
+        byte[] bytes = new byte[32];
+        random.nextBytes(bytes);
+        return new CSRFToken(Base64.getUrlEncoder().encodeToString(bytes));
+    }
+
+}

--- a/bennu-spring/src/test/java/org/fenixedu/bennu/spring/mvc/TestController.java
+++ b/bennu-spring/src/test/java/org/fenixedu/bennu/spring/mvc/TestController.java
@@ -18,6 +18,7 @@
  */
 package org.fenixedu.bennu.spring.mvc;
 
+import org.fenixedu.bennu.core.security.SkipCSRF;
 import org.fenixedu.commons.i18n.LocalizedString;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,10 +49,24 @@ public class TestController {
         throw BennuSpringTestDomainException.status(500);
     }
 
+    @SkipCSRF
     @ResponseBody
     @RequestMapping("/localized")
     public String localized(@RequestParam LocalizedString localized) {
         return localized.json().toString();
+    }
+
+    @ResponseBody
+    @RequestMapping("/csrf")
+    public String csrfChecker() {
+        return "ok";
+    }
+
+    @SkipCSRF
+    @ResponseBody
+    @RequestMapping("/csrf-ignored")
+    public String csrfIgnored() {
+        return "ok";
     }
 
 }

--- a/bennu-spring/src/test/java/org/fenixedu/bennu/spring/security/CSRFTokenTest.java
+++ b/bennu-spring/src/test/java/org/fenixedu/bennu/spring/security/CSRFTokenTest.java
@@ -1,0 +1,156 @@
+package org.fenixedu.bennu.spring.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.fenixedu.bennu.spring.BennuSpringConfiguration;
+import org.fenixedu.bennu.spring.security.CSRFTokenTest.MyConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebAppConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { BennuSpringConfiguration.class, MyConfig.class })
+public class CSRFTokenTest {
+
+    private static final CSRFToken TEST_TOKEN = new CSRFToken("RANDOM_TOKEN");
+
+    public static class MyConfig {
+
+        @Bean
+        @Order(Ordered.HIGHEST_PRECEDENCE)
+        public CSRFTokenRepository csrfTokenRepository() {
+            return new CSRFTokenRepository() {
+                @Override
+                public CSRFToken getToken(HttpServletRequest request) {
+                    return TEST_TOKEN;
+                }
+            };
+        }
+
+    }
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+    }
+
+    // GET
+
+    @Test
+    public void testGetRequestsAreNotAffected() throws Exception {
+        this.mockMvc.perform(get("/test/csrf")).andExpect(status().isOk());
+    }
+
+    // POST
+
+    @Test
+    public void testPOSTRequestsAreProperlyFiltered() throws Exception {
+        this.mockMvc.perform(post("/test/csrf")).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testPOSTRequestsWithWrongToken() throws Exception {
+        this.mockMvc.perform(post("/test/csrf").param(TEST_TOKEN.getParameterName(), "WRONG_TOKEN")).andExpect(
+                status().isBadRequest());
+    }
+
+    @Test
+    public void testPOSTRequestsWithParameterWorks() throws Exception {
+        this.mockMvc.perform(post("/test/csrf").param(TEST_TOKEN.getParameterName(), TEST_TOKEN.getToken())).andExpect(
+                status().isOk());
+    }
+
+    @Test
+    public void testPOSTRequestsWithHeaderWorks() throws Exception {
+        this.mockMvc.perform(post("/test/csrf").header(TEST_TOKEN.getHeaderName(), TEST_TOKEN.getToken())).andExpect(
+                status().isOk());
+    }
+
+    @Test
+    public void testPUTRequestsWithIgnoreAnnotationAreNotAffected() throws Exception {
+        this.mockMvc.perform(post("/test/csrf-ignored")).andExpect(status().isOk());
+    }
+
+    // POST
+
+    @Test
+    public void testPUTRequestsAreProperlyFiltered() throws Exception {
+        this.mockMvc.perform(put("/test/csrf")).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testPUTRequestsWithWrongToken() throws Exception {
+        this.mockMvc.perform(put("/test/csrf").param(TEST_TOKEN.getParameterName(), "WRONG_TOKEN")).andExpect(
+                status().isBadRequest());
+    }
+
+    @Test
+    public void testPUTRequestsWithParameterWorks() throws Exception {
+        this.mockMvc.perform(put("/test/csrf").param(TEST_TOKEN.getParameterName(), TEST_TOKEN.getToken())).andExpect(
+                status().isOk());
+    }
+
+    @Test
+    public void testPUTRequestsWithHeaderWorks() throws Exception {
+        this.mockMvc.perform(put("/test/csrf").header(TEST_TOKEN.getHeaderName(), TEST_TOKEN.getToken())).andExpect(
+                status().isOk());
+    }
+
+    @Test
+    public void testPOSTRequestsWithIgnoreAnnotationAreNotAffected() throws Exception {
+        this.mockMvc.perform(put("/test/csrf-ignored")).andExpect(status().isOk());
+    }
+
+    // DELETE
+
+    @Test
+    public void testDELETERequestsAreProperlyFiltered() throws Exception {
+        this.mockMvc.perform(delete("/test/csrf")).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testDELETERequestsWithWrongToken() throws Exception {
+        this.mockMvc.perform(delete("/test/csrf").param(TEST_TOKEN.getParameterName(), "WRONG_TOKEN")).andExpect(
+                status().isBadRequest());
+    }
+
+    @Test
+    public void testDELETERequestsWithParameterWorks() throws Exception {
+        this.mockMvc.perform(delete("/test/csrf").param(TEST_TOKEN.getParameterName(), TEST_TOKEN.getToken())).andExpect(
+                status().isOk());
+    }
+
+    @Test
+    public void testDELETERequestsWithHeaderWorks() throws Exception {
+        this.mockMvc.perform(delete("/test/csrf").header(TEST_TOKEN.getHeaderName(), TEST_TOKEN.getToken())).andExpect(
+                status().isOk());
+    }
+
+    @Test
+    public void testDELETERequestsWithIgnoreAnnotationAreNotAffected() throws Exception {
+        this.mockMvc.perform(delete("/test/csrf-ignored")).andExpect(status().isOk());
+    }
+
+}

--- a/bennu-test/src/test/java/org/fenixedu/bennu/core/security/CSRFFeatureTest.java
+++ b/bennu-test/src/test/java/org/fenixedu/bennu/core/security/CSRFFeatureTest.java
@@ -1,0 +1,136 @@
+package org.fenixedu.bennu.core.security;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Application;
+
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class CSRFFeatureTest extends JerseyTest {
+
+    @Path("resource")
+    public static class TestResource {
+
+        @GET
+        public String get() {
+            return "GET - ok";
+        }
+
+        @POST
+        public String post() {
+            return "POST - ok";
+        }
+
+        @POST
+        @SkipCSRF
+        @Path("/nocheck")
+        public String postWithoutCheck() {
+            return "POST - NOCHECK - ok";
+        }
+
+        @PUT
+        public String put() {
+            return "PUT - ok";
+        }
+
+        @PUT
+        @SkipCSRF
+        @Path("/nocheck")
+        public String putWithoutCheck() {
+            return "PUT - NOCHECK - ok";
+        }
+
+        @DELETE
+        public String delete() {
+            return "DELETE - ok";
+        }
+
+        @DELETE
+        @SkipCSRF
+        @Path("/nocheck")
+        public String deleteWithoutCheck() {
+            return "DELETE - NOCHECK - ok";
+        }
+
+    }
+
+    @Override
+    protected Application configure() {
+        return new ResourceConfig(TestResource.class, CSRFFeature.class);
+    }
+
+    // GET test
+
+    @Test
+    public void testGETRequestsAreNotAffected() {
+        assertEquals("GET - ok", target("/resource").request().get(String.class));
+    }
+
+    // POST tests
+
+    @Test(expected = BadRequestException.class)
+    public void testPOSTRequestsAreProperlyFiltered() {
+        target("/resource").request().post(Entity.html("ignore_me"), String.class);
+    }
+
+    @Test
+    public void testPOSTRequestsWithHeaderWork() {
+        assertEquals("POST - ok",
+                target("/resource").request().header("X-Requested-With", "XPTO").post(Entity.html("ignore_me"), String.class));
+    }
+
+    @Test
+    public void testPOSTRequestsWithIgnoreAnnotationAreNotAffected() {
+        assertEquals("POST - NOCHECK - ok",
+                target("/resource").path("/nocheck").request().post(Entity.html("ignore_me"), String.class));
+    }
+
+    // POST tests
+
+    @Test(expected = BadRequestException.class)
+    public void testPUTRequestsAreProperlyFiltered() {
+        target("/resource").request().put(Entity.html("ignore_me"), String.class);
+    }
+
+    @Test
+    public void testPUTRequestsWithHeaderWork() {
+        assertEquals("PUT - ok",
+                target("/resource").request().header("X-Requested-With", "XPTO").put(Entity.html("ignore_me"), String.class));
+    }
+
+    @Test
+    public void testPUTRequestsWithIgnoreAnnotationAreNotAffected() {
+        assertEquals("PUT - NOCHECK - ok",
+                target("/resource").path("/nocheck").request().put(Entity.html("ignore_me"), String.class));
+    }
+
+    // DELETE tests
+
+    @Test(expected = BadRequestException.class)
+    public void testDELETERequestsAreProperlyFiltered() {
+        target("/resource").request().delete(String.class);
+    }
+
+    @Test
+    public void testDELETERequestsWithHeaderWork() {
+        assertEquals("DELETE - ok", target("/resource").request().header("X-Requested-With", "XPTO").delete(String.class));
+    }
+
+    @Test
+    public void testDELETERequestsWithIgnoreAnnotationAreNotAffected() {
+        assertEquals("DELETE - NOCHECK - ok", target("/resource").path("/nocheck").request().delete(String.class));
+    }
+
+}

--- a/bennu-toolkit/src/main/webapp/bennu-toolkit/js/bennu-angular.js
+++ b/bennu-toolkit/src/main/webapp/bennu-toolkit/js/bennu-angular.js
@@ -136,4 +136,9 @@
 	  }
 	});
 
+	bennuToolkit.config(['$httpProvider',function($httpProvider) {
+		$httpProvider.defaults.headers.common = $httpProvider.defaults.headers.common || {};
+		$httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+	}]);
+
 })();

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/security/CSRFApiProtectionFilter.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/security/CSRFApiProtectionFilter.java
@@ -1,0 +1,39 @@
+package org.fenixedu.bennu.core.security;
+
+import java.io.IOException;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import com.google.common.base.Strings;
+
+/***
+ * 
+ * Prematching filter to prevent CSRF attacks
+ * 
+ * It will check if the header "X-Requested-With" is present in the request, and sends a {@link Status#BAD_REQUEST} response if
+ * not.
+ * 
+ * @author Sérgio Silva (sergio.silva@tecnico.ulisboa.pt)
+ * 
+ * @see CSRFFeature
+ *
+ */
+
+@PreMatching
+public class CSRFApiProtectionFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext ctx) throws IOException {
+        if (Strings.isNullOrEmpty(ctx.getHeaderString("X-Requested-With"))) {
+            throw new WebApplicationException(
+                    Response.status(Status.BAD_REQUEST)
+                            .entity("To make a successful request to this endpoint you must send X-Requested-With header with a non empty string value.")
+                            .location(ctx.getUriInfo().getBaseUri()).build());
+        }
+    }
+}

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/security/CSRFFeature.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/security/CSRFFeature.java
@@ -1,0 +1,45 @@
+package org.fenixedu.bennu.core.security;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableSet;
+
+/***
+ * 
+ * Apply {@link CSRFApiProtectionFilter} if resourceMethod is annotated with {@link POST}, {@link PUT} or {@link DELETE}
+ * 
+ * @author Sérgio Silva (sergio.silva@tecnico.ulisboa.pt)
+ *
+ */
+@Provider
+public class CSRFFeature implements DynamicFeature {
+
+    private static final Logger logger = LoggerFactory.getLogger(CSRFFeature.class);
+
+    private static final Set<Class<? extends Annotation>> toFilterAnnotations = ImmutableSet.of(POST.class, PUT.class,
+            DELETE.class);
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        if (Stream.of(resourceInfo.getResourceMethod().getAnnotations()).map(Annotation::annotationType)
+                .anyMatch(toFilterAnnotations::contains)
+                && !resourceInfo.getResourceMethod().isAnnotationPresent(SkipCSRF.class)) {
+            logger.debug("Enabling CSRF protection for {}", resourceInfo.getResourceMethod());
+            context.register(new CSRFApiProtectionFilter());
+        }
+    }
+
+}

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/security/SkipCSRF.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/security/SkipCSRF.java
@@ -1,0 +1,20 @@
+package org.fenixedu.bennu.core.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the annotated method, signaling the underlying presentation technology that CSRF validation should be skipped for this
+ * method.
+ * 
+ * @author João Carvalho (joao.pedro.carvalho@tecnico.ulisboa.pt)
+ */
+@Documented
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SkipCSRF {
+
+}

--- a/server/bennu-core/src/main/webapp/bennu-core/js/bootstrap.js
+++ b/server/bennu-core/src/main/webapp/bennu-core/js/bootstrap.js
@@ -160,4 +160,7 @@ angular.module('bootstrapModule', [])
 				field.error = null;
 			});
 		}
-	});
+	}).config(['$httpProvider',function($httpProvider) {
+		$httpProvider.defaults.headers.common = $httpProvider.defaults.headers.common || {};
+		$httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+	}]);


### PR DESCRIPTION
  * All filtered JAX-RS requests must include a X-Requested-With header
  * All filtered Spring requests must include the CSRF token as a header
    or request parameter
  * Specific endpoints may choose to bypass validation via the @SkipCSRF annotation
  * Configured the Angular toolkit to automatically add the required headers
  * Added a Spring bean to aid in adding the required tokens to JSP pages
  * Added test suites to check for the required behavior
  * Issue: BNN-171

Configures a request filter that checks for a specific header to prevent CSRF attacks
when invoking jaxrs endpoints.