### PR TITLE
PersistentGroup core methods can now be overridden

### DIFF
--- a/bennu-portal/src/main/java/org/fenixedu/bennu/portal/domain/MenuItem.java
+++ b/bennu-portal/src/main/java/org/fenixedu/bennu/portal/domain/MenuItem.java
@@ -110,7 +110,7 @@ public abstract class MenuItem extends MenuItem_Base implements Comparable<MenuI
      *         Whether the given user can access this item
      */
     public boolean isAvailable(User user) {
-        return getAccessGroup().isMember(user) && getParent().isAvailable(user);
+        return getGroup().isMember(user) && getParent().isAvailable(user);
     }
 
     /**
@@ -129,7 +129,7 @@ public abstract class MenuItem extends MenuItem_Base implements Comparable<MenuI
      * Implementation Node: This method ONLY checks the current node, not the full chain!
      */
     protected boolean isItemAvailableForCurrentUser() {
-        return getAccessGroup().isMember(Authenticate.getUser());
+        return getGroup().isMember(Authenticate.getUser());
     }
 
     /**

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentDifferenceGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentDifferenceGroup.java
@@ -22,7 +22,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.Group;
+import org.joda.time.DateTime;
 
 /**
  * Difference composition group. Can be read as members of first group except members of the remaining ones.
@@ -39,6 +41,22 @@ public final class PersistentDifferenceGroup extends PersistentDifferenceGroup_B
     @Override
     public Group toGroup() {
         return getRestSet().stream().map(PersistentGroup::toGroup).reduce(getFirst().toGroup(), Group::minus);
+    }
+
+    @Override
+    public boolean isMember(User user) {
+        if (getFirst().isMember(user)) {
+            return !getRestSet().stream().anyMatch(group -> group.isMember(user));
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isMember(User user, DateTime when) {
+        if (getFirst().isMember(user, when)) {
+            return !getRestSet().stream().anyMatch(group -> group.isMember(user, when));
+        }
+        return false;
     }
 
     @Override

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentDynamicGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentDynamicGroup.java
@@ -17,8 +17,10 @@
 package org.fenixedu.bennu.core.domain.groups;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.fenixedu.bennu.core.domain.BennuGroupIndex;
+import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.DynamicGroup;
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.security.Authenticate;
@@ -68,6 +70,26 @@ public final class PersistentDynamicGroup extends PersistentDynamicGroup_Base {
     public PersistentGroup getGroup() {
         //FIXME: remove when the framework enables read-only slots
         return super.getGroup();
+    }
+
+    @Override
+    public Set<User> getMembers() {
+        return getGroup().getMembers();
+    }
+
+    @Override
+    public Set<User> getMembers(DateTime when) {
+        return getGroup(when).getMembers(when);
+    }
+
+    @Override
+    public boolean isMember(User user) {
+        return getGroup().isMember(user);
+    }
+
+    @Override
+    public boolean isMember(User user, DateTime when) {
+        return getGroup(when).isMember(user, when);
     }
 
     public PersistentGroup getGroup(DateTime when) {

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentGroup.java
@@ -48,6 +48,12 @@ import pt.ist.fenixframework.Atomic.TxMode;
  * of groups instead of changing the current one.
  * </p>
  * 
+ * <p>
+ * <b>Note:</b> Whereas in most situations users will not deal with {@link PersistentGroup} subclasses directly, if possible, the
+ * core methods ( {@link #isMember(User)}, {@link #getMembers()}) should be invoked directly, as subclasses may have a more
+ * performant way of computing the proper values.
+ * </p>
+ * 
  * @see PersistentDynamicGroup
  * @see GroupOperator
  */
@@ -84,7 +90,7 @@ public abstract class PersistentGroup extends PersistentGroup_Base {
      * 
      * @return all member users in the system at the exact moment of the invocation
      */
-    public final Set<User> getMembers() {
+    public Set<User> getMembers() {
         return toGroup().getMembers();
     }
 
@@ -95,7 +101,7 @@ public abstract class PersistentGroup extends PersistentGroup_Base {
      *            moment when to fetch the user list.
      * @return all member users in the system at the requested moment
      */
-    public final Set<User> getMembers(DateTime when) {
+    public Set<User> getMembers(DateTime when) {
         return toGroup().getMembers(when);
     }
 
@@ -108,7 +114,7 @@ public abstract class PersistentGroup extends PersistentGroup_Base {
      * 
      * @see #verify()
      */
-    public final boolean isMember(User user) {
+    public boolean isMember(User user) {
         return toGroup().isMember(user);
     }
 
@@ -121,7 +127,7 @@ public abstract class PersistentGroup extends PersistentGroup_Base {
      *            moment when to test the user.
      * @return <code>true</code> if member, <code>false</code> otherwise
      */
-    public final boolean isMember(User user, DateTime when) {
+    public boolean isMember(User user, DateTime when) {
         return toGroup().isMember(user, when);
     }
 

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentIntersectionGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentIntersectionGroup.java
@@ -22,7 +22,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.Group;
+import org.joda.time.DateTime;
 
 /**
  * Intersection composition group.
@@ -38,6 +40,22 @@ public final class PersistentIntersectionGroup extends PersistentIntersectionGro
     @Override
     public Group toGroup() {
         return getChildrenSet().stream().map(PersistentGroup::toGroup).reduce(Group::and).orElseGet(Group::nobody);
+    }
+
+    @Override
+    public boolean isMember(User user) {
+        if (getChildrenSet().isEmpty()) {
+            return false;
+        }
+        return getChildrenSet().stream().allMatch(group -> group.isMember(user));
+    }
+
+    @Override
+    public boolean isMember(User user, DateTime when) {
+        if (getChildrenSet().isEmpty()) {
+            return false;
+        }
+        return getChildrenSet().stream().allMatch(group -> group.isMember(user, when));
     }
 
     @Override

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentNegationGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentNegationGroup.java
@@ -18,7 +18,9 @@ package org.fenixedu.bennu.core.domain.groups;
 
 import java.util.Optional;
 
+import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.Group;
+import org.joda.time.DateTime;
 
 /**
  * Inverse group of another group.
@@ -34,6 +36,16 @@ public final class PersistentNegationGroup extends PersistentNegationGroup_Base 
     @Override
     public Group toGroup() {
         return getNegated().toGroup().not();
+    }
+
+    @Override
+    public boolean isMember(User user) {
+        return !getNegated().isMember(user);
+    }
+
+    @Override
+    public boolean isMember(User user, DateTime when) {
+        return !getNegated().isMember(user, when);
     }
 
     @Override

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentUnionGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentUnionGroup.java
@@ -20,9 +20,12 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.Group;
+import org.joda.time.DateTime;
 
 /**
  * Union composition group.
@@ -38,6 +41,26 @@ public final class PersistentUnionGroup extends PersistentUnionGroup_Base {
     @Override
     public Group toGroup() {
         return getChildrenSet().stream().map(PersistentGroup::toGroup).reduce(Group.nobody(), Group::or);
+    }
+
+    @Override
+    public boolean isMember(User user) {
+        return getChildrenSet().stream().anyMatch(group -> group.isMember(user));
+    }
+
+    @Override
+    public boolean isMember(User user, DateTime when) {
+        return getChildrenSet().stream().anyMatch(group -> group.isMember(user, when));
+    }
+
+    @Override
+    public Set<User> getMembers() {
+        return getChildrenSet().stream().flatMap(group -> group.getMembers().stream()).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<User> getMembers(DateTime when) {
+        return getChildrenSet().stream().flatMap(group -> group.getMembers(when).stream()).collect(Collectors.toSet());
     }
 
     @Override

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentUserGroup.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/groups/PersistentUserGroup.java
@@ -17,6 +17,7 @@
 package org.fenixedu.bennu.core.domain.groups;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -25,6 +26,7 @@ import java.util.stream.Stream;
 import org.fenixedu.bennu.core.domain.BennuGroupIndex;
 import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.groups.Group;
+import org.joda.time.DateTime;
 
 /**
  * Groups of specific users.
@@ -35,6 +37,26 @@ public final class PersistentUserGroup extends PersistentUserGroup_Base {
     protected PersistentUserGroup(Set<User> members) {
         super();
         getMemberSet().addAll(members);
+    }
+
+    @Override
+    public Set<User> getMembers() {
+        return Collections.unmodifiableSet(getMemberSet());
+    }
+
+    @Override
+    public Set<User> getMembers(DateTime when) {
+        return getMembers();
+    }
+
+    @Override
+    public boolean isMember(User user) {
+        return getMemberSet().contains(user);
+    }
+
+    @Override
+    public boolean isMember(User user, DateTime when) {
+        return isMember(user);
     }
 
     @Override

--- a/server/bennu-io/src/main/java/org/fenixedu/bennu/io/domain/GroupBasedFile.java
+++ b/server/bennu-io/src/main/java/org/fenixedu/bennu/io/domain/GroupBasedFile.java
@@ -20,7 +20,7 @@ public final class GroupBasedFile extends GroupBasedFile_Base {
 
     @Override
     public boolean isAccessible(User user) {
-        return getAccessGroup().isMember(user);
+        return getGroup().isMember(user);
     }
 
     @Override


### PR DESCRIPTION
  * This allows for direct references to PersistentGroups to bypass useless non-persistent group instantiation
  * Adjusted PersistentGroup usages to use the direct methods
  * Issue: BNN-203