### PR TITLE
JsonAwareResource API changed to JsonElement. BNN-146 BNN-147 #resolve

### DIFF
--- a/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ExternalApplicationAuthorizationResources.java
+++ b/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ExternalApplicationAuthorizationResources.java
@@ -31,12 +31,14 @@ import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.rest.BennuRestResource;
 import org.fenixedu.bennu.oauth.domain.ApplicationUserAuthorization;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-oauth/authorizations")
 public class ExternalApplicationAuthorizationResources extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String myAuthorizations() {
+    public JsonElement myAuthorizations() {
         return view(verifyAndGetRequestAuthor().getApplicationUserAuthorizationSet());
     }
 
@@ -46,7 +48,7 @@ public class ExternalApplicationAuthorizationResources extends BennuRestResource
         User user = verifyAndGetRequestAuthor();
         if (authorization.getUser() == user || isManager(user)) {
             authorization.delete();
-            return Response.ok().build();
+            return ok();
         }
         return null;
     }

--- a/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ExternalApplicationAuthorizationSessionResources.java
+++ b/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ExternalApplicationAuthorizationSessionResources.java
@@ -34,13 +34,15 @@ import org.fenixedu.bennu.core.rest.BennuRestResource;
 import org.fenixedu.bennu.oauth.domain.ApplicationUserAuthorization;
 import org.fenixedu.bennu.oauth.domain.ApplicationUserSession;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-oauth/sessions/")
 public class ExternalApplicationAuthorizationSessionResources extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/{session}")
-    public String authorizations(@PathParam("session") ApplicationUserAuthorization authorization) {
+    public JsonElement authorizations(@PathParam("session") ApplicationUserAuthorization authorization) {
         User user = verifyAndGetRequestAuthor();
         if (authorization.getUser() == user || isManager(user)) {
             return view(authorization.getSessionSet());
@@ -56,7 +58,7 @@ public class ExternalApplicationAuthorizationSessionResources extends BennuRestR
             atomic(() -> {
                 session.delete();
             });
-            return Response.ok().build();
+            return ok();
         }
         return null;
     }

--- a/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ExternalApplicationScopesResource.java
+++ b/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ExternalApplicationScopesResource.java
@@ -37,12 +37,14 @@ import org.fenixedu.bennu.core.rest.BennuRestResource;
 import org.fenixedu.bennu.oauth.domain.ExternalApplication;
 import org.fenixedu.bennu.oauth.domain.ExternalApplicationScope;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-oauth/scopes")
 public class ExternalApplicationScopesResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getScopes() {
+    public JsonElement getScopes() {
         verifyAndGetRequestAuthor();
         return view(Bennu.getInstance().getScopesSet().stream().filter(s -> !s.getService()));
     }
@@ -50,7 +52,7 @@ public class ExternalApplicationScopesResource extends BennuRestResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/all")
-    public String getAllScopes() {
+    public JsonElement getAllScopes() {
         accessControl(Group.managers());
         return view(Bennu.getInstance().getScopesSet());
     }
@@ -58,7 +60,7 @@ public class ExternalApplicationScopesResource extends BennuRestResource {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public String createScope(String json) {
+    public JsonElement createScope(JsonElement json) {
         accessControl(Group.managers());
         return view(create(json, ExternalApplicationScope.class));
     }
@@ -67,7 +69,7 @@ public class ExternalApplicationScopesResource extends BennuRestResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
     @Path("/{scope}")
-    public String updateScope(@PathParam("scope") ExternalApplicationScope scope, String json) {
+    public JsonElement updateScope(@PathParam("scope") ExternalApplicationScope scope, JsonElement json) {
         accessControl(Group.managers());
         return view(update(json, scope));
     }
@@ -82,7 +84,7 @@ public class ExternalApplicationScopesResource extends BennuRestResource {
             }
             Bennu.getInstance().removeScopes(scope);
         });
-        return Response.ok().build();
+        return ok();
     }
 
 }

--- a/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ServiceApplicationResource.java
+++ b/bennu-oauth/src/main/java/org/fenixedu/bennu/oauth/api/ServiceApplicationResource.java
@@ -30,6 +30,8 @@ import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.oauth.domain.ExternalApplication;
 import org.fenixedu.bennu.oauth.domain.ServiceApplication;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-oauth/service-applications")
 public class ServiceApplicationResource extends ExternalApplicationResource {
 
@@ -44,7 +46,7 @@ public class ServiceApplicationResource extends ExternalApplicationResource {
     }
 
     @Override
-    public String myApplications() {
+    public JsonElement myApplications() {
         throw new WebApplicationException(Status.NOT_FOUND);
     }
 
@@ -54,12 +56,12 @@ public class ServiceApplicationResource extends ExternalApplicationResource {
     }
 
     @Override
-    protected ExternalApplication create(String json) {
+    protected ExternalApplication create(JsonElement json) {
         return create(json, ServiceApplication.class);
     }
 
     @Override
-    protected String update(ExternalApplication application, String json, User currentUser) {
+    protected JsonElement update(ExternalApplication application, JsonElement json, User currentUser) {
         return view(update(json, application));
     }
 

--- a/bennu-portal/src/main/java/org/fenixedu/bennu/portal/rest/PortalConfigurationResource.java
+++ b/bennu-portal/src/main/java/org/fenixedu/bennu/portal/rest/PortalConfigurationResource.java
@@ -7,6 +7,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.CacheControl;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.MediaType;
@@ -17,12 +18,14 @@ import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.rest.BennuRestResource;
 import org.fenixedu.bennu.portal.domain.PortalConfiguration;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-portal/configuration")
 public class PortalConfigurationResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String viewConfig() {
+    public JsonElement viewConfig() {
         accessControl(Group.managers());
         return view(PortalConfiguration.getInstance());
     }
@@ -40,7 +43,7 @@ public class PortalConfigurationResource extends BennuRestResource {
             }
             return Response.ok(instance.getLogo(), instance.getLogoType()).cacheControl(CACHE_CONTROL).tag(etag).build();
         }
-        return Response.status(Status.NOT_FOUND).build();
+        throw new WebApplicationException(Status.NOT_FOUND);
     }
 
     private EntityTag buildETag(PortalConfiguration instance) {
@@ -54,14 +57,14 @@ public class PortalConfigurationResource extends BennuRestResource {
         if (instance != null && instance.getFavicon() != null) {
             return Response.ok(instance.getFavicon(), instance.getFaviconType()).cacheControl(CACHE_CONTROL).build();
         }
-        return Response.status(Status.NOT_FOUND).build();
+        throw new WebApplicationException(Status.NOT_FOUND);
     }
 
     @PUT
     @Path("{oid}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String updateConfig(String jsonData, @PathParam("oid") String oid) {
+    public JsonElement updateConfig(JsonElement jsonData, @PathParam("oid") String oid) {
         accessControl(Group.managers());
         return view(update(jsonData, readDomainObject(oid)));
     }

--- a/bennu-portal/src/main/java/org/fenixedu/bennu/portal/rest/PortalDataResource.java
+++ b/bennu-portal/src/main/java/org/fenixedu/bennu/portal/rest/PortalDataResource.java
@@ -16,11 +16,11 @@ import com.google.gson.JsonObject;
 public class PortalDataResource extends BennuRestResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getMenu() {
+    public JsonObject getMenu() {
         final JsonObject hostMenuView = new JsonObject();
         merge(hostMenuView, getBuilder().view(PortalConfiguration.getInstance(), PortalMenuViewer.class).getAsJsonObject());
         merge(hostMenuView, getBuilder().view(getCasConfigContext()).getAsJsonObject());
         merge(hostMenuView, getBuilder().view(null, Void.class, AuthenticatedUserViewer.class).getAsJsonObject());
-        return toJson(hostMenuView);
+        return hostMenuView;
     }
 }

--- a/bennu-test/src/test/java/org/fenixedu/bennu/core/rest/GsonBodyReaderWriterTest.java
+++ b/bennu-test/src/test/java/org/fenixedu/bennu/core/rest/GsonBodyReaderWriterTest.java
@@ -6,6 +6,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
 import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -13,12 +14,19 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
+import org.fenixedu.bennu.core.domain.Bennu;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import pt.ist.fenixframework.test.core.FenixFrameworkRunner;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -35,7 +43,16 @@ import com.google.gson.JsonPrimitive;
  * @see JerseyTest
  *
  */
+@RunWith(FenixFrameworkRunner.class)
 public class GsonBodyReaderWriterTest extends JerseyTest {
+
+    private static String urlEncode(String payload) {
+        try {
+            return URLEncoder.encode(payload, "UTF-8").replace("+", "%20");
+        } catch (UnsupportedEncodingException e) {
+            throw new Error(e); //will never happen
+        }
+    }
 
     @Path("resource")
     public static class TestResource {
@@ -71,6 +88,32 @@ public class GsonBodyReaderWriterTest extends JerseyTest {
             return array;
         }
 
+        @Path("/readerwritertest")
+        @GET
+        @Consumes(MediaType.APPLICATION_JSON)
+        @Produces(MediaType.APPLICATION_JSON)
+        public JsonObject map(@QueryParam("data") JsonObject data) {
+            return data;
+        }
+
+        @Path("/readerwritertestparams")
+        @POST
+        @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Produces(MediaType.APPLICATION_JSON)
+        public JsonArray readerwritertestparams(@QueryParam("bennu") Bennu bennu, @QueryParam("query") JsonObject data,
+                @FormParam("body") JsonElement body) {
+            JsonArray array = new JsonArray();
+            array.add(new JsonPrimitive("Doing map for " + data.get("name").getAsString()));
+            array.add(new JsonPrimitive(bennu.getExternalId()));
+            for (JsonElement el : body.getAsJsonArray()) {
+                final int newValue = el.getAsJsonObject().get("value").getAsInt() * 2;
+                el.getAsJsonObject().addProperty("value", newValue);
+                array.add(el);
+            }
+
+            return array;
+        }
+
     }
 
     @Override
@@ -81,7 +124,8 @@ public class GsonBodyReaderWriterTest extends JerseyTest {
 
     @Override
     protected Application configure() {
-        return new ResourceConfig(TestResource.class, JsonParamConverterProvider.class, JsonBodyReaderWriter.class);
+        return new ResourceConfig(TestResource.class, JsonParamConverterProvider.class, JsonBodyReaderWriter.class,
+                DomainObjectParamConverter.class);
     }
 
     @Test
@@ -107,16 +151,40 @@ public class GsonBodyReaderWriterTest extends JerseyTest {
     }
 
     @Test
+    public void testJsonObjectReaderWriter() throws UnsupportedEncodingException {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("value", 1);
+
+        JsonObject response =
+                target("resource").path("readerwritertest").queryParam("data", urlEncode(payload.toString()))
+                        .request(MediaType.APPLICATION_JSON).get(JsonObject.class);
+
+        assertEquals(payload.toString(), response.toString());
+    }
+
+    @Test
+    public void testMalformedJson() throws UnsupportedEncodingException {
+
+        String payload = "{'xpto': '}";
+
+        Response response =
+                target("resource").path("readerwritertest").queryParam("data", urlEncode(payload))
+                        .request(MediaType.APPLICATION_JSON).get();
+
+        assertEquals(Status.BAD_REQUEST, response.getStatusInfo());
+    }
+
+    @Test
     public void testBoth() throws UnsupportedEncodingException {
         JsonObject payload = new JsonObject();
         payload.addProperty("name", "testBoth");
 
-        String array = "[{'value' : 1}, {'value' : 2}, {'value' : 3} , {'value' : 4}]";
+        String values = "[{\"value\" : 1}, {\"value\" : 2}, {\"value\" : 3} , {\"value\" : 4}]";
 
         final JsonArray mapResult =
-                target("resource").path("readerwritertest").queryParam("data", URLEncoder.encode(payload.toString(), "UTF-8"))
+                target("resource").path("readerwritertest").queryParam("data", urlEncode(payload.toString()))
                         .request(MediaType.APPLICATION_JSON)
-                        .post(Entity.entity(array, MediaType.APPLICATION_JSON), JsonArray.class);
+                        .post(Entity.entity(values, MediaType.APPLICATION_JSON), JsonArray.class);
 
         assertEquals("Doing map for testBoth", mapResult.get(0).getAsString());
         assertEquals(2, mapResult.get(1).getAsJsonObject().get("value").getAsInt());
@@ -125,4 +193,28 @@ public class GsonBodyReaderWriterTest extends JerseyTest {
         assertEquals(8, mapResult.get(4).getAsJsonObject().get("value").getAsInt());
     }
 
+    @Test
+    public void testWithBodyAndParams() throws UnsupportedEncodingException {
+        JsonObject payload = new JsonObject();
+        final String bennuId = Bennu.getInstance().getExternalId();
+
+        payload.addProperty("name", "testBoth");
+
+        String values = "[{\"value\" : 1}, {\"value\" : 2}, {\"value\" : 3} , {\"value\" : 4}]";
+
+        Form form = new Form();
+        form.param("body", values);
+
+        final JsonArray mapResult =
+                target("resource").path("readerwritertestparams").queryParam("bennu", bennuId)
+                        .queryParam("query", urlEncode(payload.toString())).request(MediaType.APPLICATION_JSON)
+                        .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE), JsonArray.class);
+
+        assertEquals("Doing map for testBoth", mapResult.get(0).getAsString());
+        assertEquals(bennuId, mapResult.get(1).getAsString());
+        assertEquals(2, mapResult.get(2).getAsJsonObject().get("value").getAsInt());
+        assertEquals(4, mapResult.get(3).getAsJsonObject().get("value").getAsInt());
+        assertEquals(6, mapResult.get(4).getAsJsonObject().get("value").getAsInt());
+        assertEquals(8, mapResult.get(5).getAsJsonObject().get("value").getAsInt());
+    }
 }

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/BennuRestResource.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/BennuRestResource.java
@@ -5,6 +5,7 @@ import java.net.URISyntaxException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 
 import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.domain.exceptions.AuthorizationException;
@@ -107,6 +108,10 @@ public abstract class BennuRestResource extends JsonAwareResource {
 
     protected String getHost() {
         return request.getServerName();
+    }
+
+    protected Response ok() {
+        return Response.ok().build();
     }
 
 }

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/JsonAwareResource.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/JsonAwareResource.java
@@ -48,51 +48,52 @@ public class JsonAwareResource {
         BUILDER.setDefault(objectClass, registeeClass);
     }
 
-    public final String view(Object object) {
+    public final JsonElement view(Object object) {
         return view(object, (Class<? extends JsonViewer<?>>) null);
     }
 
-    public final String view(Object object, Class<? extends JsonViewer<?>> viewerClass) {
+    public final JsonElement view(Object object, Class<? extends JsonViewer<?>> viewerClass) {
         if (object == null) {
             return view(object, (Class<?>) null, viewerClass);
         }
         return view(object, object.getClass(), viewerClass);
     }
 
-    public final String view(Object object, Class<?> objectClass, Class<? extends JsonViewer<?>> viewerClass) {
-        return GSON.toJson(BUILDER.view(object, objectClass, viewerClass));
+    public final JsonElement view(Object object, Class<?> objectClass, Class<? extends JsonViewer<?>> viewerClass) {
+        return BUILDER.view(object, objectClass, viewerClass);
     }
 
-    public final String view(Object object, String collectionKey) {
+    public final JsonElement view(Object object, String collectionKey) {
         return view(object, collectionKey, null);
     }
 
-    public final String view(Object object, String collectionKey, Class<? extends JsonViewer<?>> viewerClass) {
+    public final JsonElement view(Object object, String collectionKey, Class<? extends JsonViewer<?>> viewerClass) {
         if (object == null) {
             return view(object, (Class<?>) null, collectionKey, viewerClass);
         }
         return view(object, object.getClass(), collectionKey, viewerClass);
     }
 
-    public final String view(Object object, Class<?> objectClass, String collectionKey, Class<? extends JsonViewer<?>> viewerClass) {
+    public final JsonElement view(Object object, Class<?> objectClass, String collectionKey,
+            Class<? extends JsonViewer<?>> viewerClass) {
         JsonObject jsonObject = new JsonObject();
         jsonObject.add(collectionKey, BUILDER.view(object, objectClass, viewerClass));
-        return GSON.toJson(jsonObject);
+        return jsonObject;
     }
 
-    public final String viewPaginated(List<?> object, String collectionKey, int skip, int pageSize) {
+    public final JsonElement viewPaginated(List<?> object, String collectionKey, int skip, int pageSize) {
         return viewPaginated(object, collectionKey, null, skip, pageSize);
     }
 
-    public final String viewPaginated(List<?> object, String collectionKey, Class<? extends JsonViewer<?>> viewerClass, int skip,
-            int pageSize) {
+    public final JsonElement viewPaginated(List<?> object, String collectionKey, Class<? extends JsonViewer<?>> viewerClass,
+            int skip, int pageSize) {
         if (object == null) {
             return viewPaginated(null, (Class<?>) null, collectionKey, viewerClass, skip, pageSize);
         }
         return viewPaginated(object, object.getClass(), collectionKey, viewerClass, skip, pageSize);
     }
 
-    public final String viewPaginated(List<?> object, Class<?> objectClass, String collectionKey,
+    public final JsonElement viewPaginated(List<?> object, Class<?> objectClass, String collectionKey,
             Class<? extends JsonViewer<?>> viewerClass, int skip, int pageSize) {
         JsonObject jsonObject = new JsonObject();
         if (object == null) {
@@ -104,39 +105,37 @@ public class JsonAwareResource {
                     viewerClass));
             jsonObject.addProperty("total", object.size());
         }
-        return GSON.toJson(jsonObject);
+        return jsonObject;
     }
 
-    public <T> T create(String jsonData, Class<T> clazz) {
+    public <T> T create(JsonElement jsonData, Class<T> clazz) {
         return create(jsonData, clazz, null);
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T create(String jsonData, Class<T> clazz, Class<? extends JsonCreator<? extends T>> jsonCreatorClass) {
+    public <T> T create(JsonElement jsonData, Class<T> clazz, Class<? extends JsonCreator<? extends T>> jsonCreatorClass) {
         LOG.trace("Create instance of {} with data {}", clazz.getSimpleName(), jsonData);
         return (T) innerCreate(jsonData, clazz, jsonCreatorClass);
     }
 
     @Atomic(mode = TxMode.WRITE)
-    private Object innerCreate(String jsonData, Class<?> clazz, Class<? extends JsonCreator<?>> jsonCreatorClass) {
-        final JsonElement parse = parse(jsonData);
-        return BUILDER.create(parse, clazz, jsonCreatorClass);
+    private Object innerCreate(JsonElement jsonData, Class<?> clazz, Class<? extends JsonCreator<?>> jsonCreatorClass) {
+        return BUILDER.create(jsonData, clazz, jsonCreatorClass);
     }
 
-    public <T> T update(String jsonData, T object) {
+    public <T> T update(JsonElement jsonData, T object) {
         return update(jsonData, object, null);
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T update(String jsonData, T object, Class<? extends JsonUpdater<? extends T>> jsonUpdaterClass) {
+    public <T> T update(JsonElement jsonData, T object, Class<? extends JsonUpdater<? extends T>> jsonUpdaterClass) {
         LOG.trace("Update instance {} with data {}", object.toString(), jsonData);
         return (T) innerUpdate(jsonData, object, jsonUpdaterClass);
     }
 
     @Atomic(mode = TxMode.WRITE)
-    private Object innerUpdate(String jsonData, Object object, Class<? extends JsonUpdater<?>> jsonUpdaterClass) {
-        final JsonElement parse = parse(jsonData);
-        return BUILDER.update(parse, object, jsonUpdaterClass);
+    private Object innerUpdate(JsonElement jsonData, Object object, Class<? extends JsonUpdater<?>> jsonUpdaterClass) {
+        return BUILDER.update(jsonData, object, jsonUpdaterClass);
     }
 
     protected JsonElement parse(String jsonString) {

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/JsonBodyReaderWriter.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/JsonBodyReaderWriter.java
@@ -50,7 +50,8 @@ public class JsonBodyReaderWriter<T extends JsonElement> implements MessageBodyR
 
     @Override
     public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return (JsonElement.class.isAssignableFrom(type) || JsonElement.class.isAssignableFrom((Class<?>) genericType));
+        // ignore media type parameters
+        return MediaType.APPLICATION_JSON_TYPE.equals(new MediaType(mediaType.getType(), mediaType.getSubtype()));
     }
 
     @Override

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/JsonParamConverterProvider.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/JsonParamConverterProvider.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Type;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.ParamConverter;
@@ -60,7 +61,7 @@ public class JsonParamConverterProvider implements ParamConverterProvider {
                     return reader.readFrom(rawType, genericType, annotations, MediaType.APPLICATION_JSON_TYPE, null,
                             new ByteArrayInputStream(value.getBytes()));
                 } catch (WebApplicationException | IOException e) {
-                    return null;
+                    throw new WebApplicationException(e, Status.BAD_REQUEST);
                 }
             }
 
@@ -71,7 +72,7 @@ public class JsonParamConverterProvider implements ParamConverterProvider {
                     writer.writeTo(value, rawType, genericType, annotations, MediaType.APPLICATION_JSON_TYPE, null, baos);
                     baos.flush();
                 } catch (IOException e) {
-                    return null;
+                    throw new WebApplicationException(e, Status.BAD_REQUEST);
                 }
                 return baos.toString();
             }

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/LogbackResource.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/LogbackResource.java
@@ -36,18 +36,19 @@ public class LogbackResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getAllLoggers() {
+    public JsonObject getAllLoggers() {
         accessControl(Group.managers());
         if (available) {
-            return Holder.getAllLoggers().toString();
-        } else {
-            return "{ 'loggers': [] }";
+            return Holder.getAllLoggers();
         }
+        JsonObject empty = new JsonObject();
+        empty.add("loggers", new JsonArray());
+        return empty;
     }
 
     @POST
     @Path("/{name}/{level}")
-    public String setLogLevel(@PathParam("name") String loggerName, @PathParam("level") String level) {
+    public JsonObject setLogLevel(@PathParam("name") String loggerName, @PathParam("level") String level) {
         accessControl(Group.managers());
         if (available) {
             Holder.setLevel(loggerName, level);
@@ -62,16 +63,18 @@ public class LogbackResource extends BennuRestResource {
      */
     private static final class Holder {
         public static JsonObject getAllLoggers() {
+            JsonArray loggers = new JsonArray();
+
             LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
-            JsonArray array = new JsonArray();
             for (Logger logger : context.getLoggerList()) {
                 JsonObject obj = new JsonObject();
                 obj.addProperty("name", logger.getName());
                 obj.addProperty("level", logger.getEffectiveLevel().toString());
-                array.add(obj);
+                loggers.add(obj);
             }
+
             JsonObject obj = new JsonObject();
-            obj.add("loggers", array);
+            obj.add("loggers", loggers);
             obj.addProperty("server", serverName);
             return obj;
         }

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/ProfileResource.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/ProfileResource.java
@@ -37,11 +37,13 @@ import org.fenixedu.commons.i18n.I18N;
 import pt.ist.fenixframework.Atomic;
 import pt.ist.fenixframework.Atomic.TxMode;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-core/profile")
 public class ProfileResource extends BennuRestResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getProfile() {
+    public JsonElement getProfile() {
         return view(null, Void.class, AuthenticatedUserViewer.class);
     }
 
@@ -60,7 +62,7 @@ public class ProfileResource extends BennuRestResource {
     @POST
     @Path("login")
     @Produces(MediaType.APPLICATION_JSON)
-    public String login(@FormParam("username") String username, @FormParam("password") String password) {
+    public JsonElement login(@FormParam("username") String username, @FormParam("password") String password) {
         if (!CoreConfiguration.casConfig().isCasEnabled()) {
             Authenticate.login(request.getSession(true), username, password);
             return view(null, Void.class, AuthenticatedUserViewer.class);
@@ -71,7 +73,7 @@ public class ProfileResource extends BennuRestResource {
     @GET
     @Path("logout")
     @Produces(MediaType.APPLICATION_JSON)
-    public String logout(@Context HttpServletResponse response) {
+    public JsonElement logout(@Context HttpServletResponse response) {
         accessControl(Group.logged());
         Authenticate.logout(request.getSession(false));
         if (CoreConfiguration.casConfig().isCasEnabled()) {
@@ -88,7 +90,7 @@ public class ProfileResource extends BennuRestResource {
     @POST
     @Path("locale/{tag}")
     @Produces(MediaType.APPLICATION_JSON)
-    public String changeLocale(@PathParam("tag") String localeTag) {
+    public JsonElement changeLocale(@PathParam("tag") String localeTag) {
         try {
             Locale locale = new Builder().setLanguageTag(localeTag).build();
             if (CoreConfiguration.supportedLocales().contains(locale)) {
@@ -111,7 +113,7 @@ public class ProfileResource extends BennuRestResource {
     @POST
     @Path("preferred-locale/{tag}")
     @Produces(MediaType.APPLICATION_JSON)
-    public String changePreferredLocale(@PathParam("tag") String localeTag) {
+    public JsonElement changePreferredLocale(@PathParam("tag") String localeTag) {
         accessControl(Group.logged());
         try {
             Locale locale = new Builder().setLanguageTag(localeTag).build();

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/SystemResource.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/SystemResource.java
@@ -58,7 +58,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.json.adapters.KeyValuePropertiesViewer;
@@ -88,7 +87,7 @@ public class SystemResource extends BennuRestResource {
     @Path("info")
     @SuppressWarnings("restriction")
     @Produces({ MediaType.APPLICATION_JSON })
-    public Response info(@Context HttpServletRequest request, @QueryParam("full") @DefaultValue("true") Boolean full) {
+    public JsonObject info(@Context HttpServletRequest request, @QueryParam("full") @DefaultValue("true") Boolean full) {
         accessControl(Group.managers());
         JsonObject json = new JsonObject();
 
@@ -206,7 +205,7 @@ public class SystemResource extends BennuRestResource {
 
         json.add("metrics", metrics);
 
-        return Response.ok(toJson(json)).build();
+        return json;
     }
 
     private static JsonElement libs;
@@ -244,7 +243,7 @@ public class SystemResource extends BennuRestResource {
     @GET
     @Path("thread-dump")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response threadDump() {
+    public JsonObject threadDump() {
         accessControl(Group.managers());
         JsonObject json = new JsonObject();
         JsonArray array = new JsonArray();
@@ -277,13 +276,13 @@ public class SystemResource extends BennuRestResource {
 
         json.addProperty("totalThreads", total);
         json.add("threads", array);
-        return Response.ok(toJson(json)).build();
+        return json;
     }
 
     @GET
     @Path("healthcheck")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response healthChecks() {
+    public JsonArray healthChecks() {
         accessControl(Group.managers());
         JsonArray json = new JsonArray();
 
@@ -298,7 +297,7 @@ public class SystemResource extends BennuRestResource {
             json.add(obj);
         }
 
-        return Response.ok(toJson(json)).build();
+        return json;
     }
 
     private static final Collection<Healthcheck> healthchecks = new ConcurrentLinkedQueue<>();
@@ -310,7 +309,7 @@ public class SystemResource extends BennuRestResource {
     @GET
     @Path("/jmx")
     @Produces(MediaType.APPLICATION_JSON)
-    public String getJmxInfo() {
+    public JsonObject getJmxInfo() {
         accessControl(Group.managers());
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
         Set<ObjectInstance> objects = mbs.queryMBeans(null, null);
@@ -322,13 +321,13 @@ public class SystemResource extends BennuRestResource {
             }
             json.get(domain).getAsJsonArray().add(getBuilder().view(instance.getObjectName()));
         }
-        return toJson(json);
+        return json;
     }
 
     @GET
     @Path("/modules")
     @Produces(MediaType.APPLICATION_JSON)
-    public String moduleInfo() {
+    public JsonElement moduleInfo() {
         return view(FenixFramework.getProject().getProjects(), "modules");
     }
 

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/UserResource.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/UserResource.java
@@ -16,9 +16,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.fenixedu.bennu.core.domain.Bennu;
@@ -26,6 +26,7 @@ import org.fenixedu.bennu.core.domain.User;
 import org.fenixedu.bennu.core.domain.UserProfile;
 import org.fenixedu.bennu.core.groups.Group;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 @Path("/bennu-core/users")
@@ -34,63 +35,62 @@ public class UserResource extends BennuRestResource {
     @POST
     @Path("find")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response findUser(@QueryParam("query") String query, @QueryParam("maxHits") @DefaultValue("20") Integer maxHits) {
+    public JsonElement findUser(@QueryParam("query") String query, @QueryParam("maxHits") @DefaultValue("20") Integer maxHits) {
         if (query == null) {
-            return Response.status(Status.BAD_REQUEST).build();
+            throw new WebApplicationException(Status.BAD_REQUEST);
         }
         Stream<User> results =
                 Stream.concat(Stream.of(User.findByUsername(query)),
                         UserProfile.searchByName(query, Integer.MAX_VALUE).map(UserProfile::getUser)).filter(Objects::nonNull)
                         .distinct().limit(maxHits);
-        return Response.ok(view(results, "users")).build();
+        return view(results, "users");
     }
 
     @GET
     @Path("/{oid}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getUser(@PathParam("oid") String externalId) {
-        return Response.ok(view(readDomainObject(externalId))).build();
+    public JsonElement getUser(@PathParam("oid") String externalId) {
+        return view(readDomainObject(externalId));
     }
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response create(String json) {
+    public JsonElement create(JsonElement json) {
         accessControl(Group.managers());
-        return Response.ok(view(create(json, User.class))).build();
+        return view(create(json, User.class));
     }
 
     @PUT
     @Path("/{username}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response update(String json, @PathParam("username") String username) {
+    public JsonElement update(JsonElement json, @PathParam("username") String username) {
         accessControl(Group.managers());
         User user = User.findByUsername(username);
         if (user == null) {
-            return Response.status(Status.NOT_FOUND).build();
+            throw new WebApplicationException(Status.NOT_FOUND);
         } else {
-            return Response.ok(view(update(json, user))).build();
+            return view(update(json, user));
         }
     }
 
     @GET
     @Path("/username/{username}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response byUsername(@PathParam("username") String username) {
+    public JsonElement byUsername(@PathParam("username") String username) {
         accessControl(Group.managers());
         User user = User.findByUsername(username);
         if (user == null) {
-            return Response.status(Status.NOT_FOUND).build();
-        } else {
-            return Response.ok(view(user)).build();
+            throw new WebApplicationException(Status.NOT_FOUND);
         }
+        return view(user);
     }
 
     @GET
     @Path("/data")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response userData(@Context HttpServletRequest request) {
+    public JsonElement userData(@Context HttpServletRequest request) {
         accessControl(Group.managers());
         JsonObject json = new JsonObject();
 
@@ -106,7 +106,7 @@ public class UserResource extends BennuRestResource {
             // Ignore, not on Tomcat
         }
 
-        return Response.ok(json.toString()).build();
+        return json;
     }
 
 }

--- a/server/bennu-io/src/main/java/org/fenixedu/bennu/io/rest/FileStorageResource.java
+++ b/server/bennu-io/src/main/java/org/fenixedu/bennu/io/rest/FileStorageResource.java
@@ -8,8 +8,10 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.rest.BennuRestResource;
@@ -21,6 +23,7 @@ import org.fenixedu.bennu.io.domain.LocalFileSystemStorage;
 
 import pt.ist.fenixframework.Atomic;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 @Path("/bennu-io/storage")
@@ -28,7 +31,7 @@ public class FileStorageResource extends BennuRestResource {
 
     @POST
     @Path("/default/{storage}")
-    public String setDefault(@PathParam("storage") String storageId) {
+    public JsonElement setDefault(@PathParam("storage") String storageId) {
         accessControl(Group.managers());
         innerSetDefault(this.<FileStorage> readDomainObject(storageId));
         return all();
@@ -42,7 +45,7 @@ public class FileStorageResource extends BennuRestResource {
     @POST
     @Path("/domain/{name}")
     @Produces(MediaType.APPLICATION_JSON)
-    public String createDomainStorage(@PathParam("name") String name) {
+    public JsonElement createDomainStorage(@PathParam("name") String name) {
         accessControl(Group.managers());
         return view(createDomainStorageService(name));
     }
@@ -51,14 +54,14 @@ public class FileStorageResource extends BennuRestResource {
     @Path("/lfs")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String createLFSStorage(String json) {
+    public JsonElement createLFSStorage(JsonElement json) {
         accessControl(Group.managers());
         return view(create(json, LocalFileSystemStorage.class));
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String all() {
+    public JsonElement all() {
         accessControl(Group.managers());
         return view(FileSupport.getInstance().getFileStorageSet(), "storages");
     }
@@ -66,13 +69,13 @@ public class FileStorageResource extends BennuRestResource {
     @GET
     @Path("/count")
     @Produces(MediaType.APPLICATION_JSON)
-    public String fileCount() {
+    public JsonObject fileCount() {
         accessControl(Group.managers());
         JsonObject json = new JsonObject();
         for (FileStorage store : FileSupport.getInstance().getFileStorageSet()) {
             json.addProperty(store.getExternalId(), store.getFileSet().size());
         }
-        return json.toString();
+        return json;
     }
 
     @Atomic
@@ -83,15 +86,15 @@ public class FileStorageResource extends BennuRestResource {
     @DELETE
     @Path("{oid}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response delete(@PathParam("oid") String storageOid) {
+    public JsonElement delete(@PathParam("oid") String storageOid) {
         accessControl(Group.managers());
         final FileStorage fileStorage = (FileStorage) readDomainObject(storageOid);
-        final String response = view(fileStorage);
+        final JsonElement response = view(fileStorage);
         Boolean deleteStorage = deleteStorage(fileStorage);
         if (deleteStorage) {
-            return Response.ok(response).build();
+            return response;
         }
-        return Response.noContent().build();
+        throw new WebApplicationException(Status.NO_CONTENT);
     }
 
     @Atomic
@@ -104,7 +107,7 @@ public class FileStorageResource extends BennuRestResource {
     public Response convertFileStorage(@PathParam("oid") String fileStorageOid) {
         accessControl(Group.managers());
         GenericFile.convertFileStorages((FileStorage) readDomainObject(fileStorageOid));
-        return Response.ok().build();
+        return ok();
     }
 
 }

--- a/server/bennu-io/src/main/java/org/fenixedu/bennu/io/rest/StorageConfigurationResource.java
+++ b/server/bennu-io/src/main/java/org/fenixedu/bennu/io/rest/StorageConfigurationResource.java
@@ -14,12 +14,14 @@ import org.fenixedu.bennu.io.domain.FileSupport;
 
 import pt.ist.fenixframework.Atomic;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-io/storage/config")
 public class StorageConfigurationResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String all() {
+    public JsonElement all() {
         accessControl(Group.managers());
         createMissingConfigurations();
         return view(FileSupport.getInstance().getConfigurationSet(), "storageConfigurations");
@@ -33,7 +35,7 @@ public class StorageConfigurationResource extends BennuRestResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String post(String json) {
+    public JsonElement post(JsonElement json) {
         accessControl(Group.managers());
         create(json, FileStorageConfiguration.class);
         return all();

--- a/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/CustomTaskResource.java
+++ b/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/CustomTaskResource.java
@@ -17,23 +17,22 @@ public class CustomTaskResource extends BennuRestResource {
 
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response addCustomTask(String jsonCode) {
+    public Response addCustomTask(JsonObject jsonCode) {
         accessControl(Group.managers());
         getClassBean(jsonCode).run();
-        return Response.ok().build();
+        return ok();
     }
 
-    private ClassBean getClassBean(String jsonCode) {
-        JsonObject parse = parse(jsonCode).getAsJsonObject();
-        return new ClassBean(parse.get("name").getAsString(), parse.get("code").getAsString());
+    private ClassBean getClassBean(JsonObject jsonCode) {
+        return new ClassBean(jsonCode.get("name").getAsString(), jsonCode.get("code").getAsString());
     }
 
     @PUT
     @Path("compile")
     @Consumes(MediaType.APPLICATION_JSON)
-    public Response compileCustomTask(String jsonCode) {
+    public JsonObject compileCustomTask(JsonObject jsonCode) {
         accessControl(Group.managers());
-        return Response.ok(toJson(getClassBean(jsonCode).compile())).build();
+        return getClassBean(jsonCode).compile();
     }
 
 }

--- a/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/ExecutionLogResource.java
+++ b/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/ExecutionLogResource.java
@@ -6,20 +6,22 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.rest.BennuRestResource;
 import org.fenixedu.bennu.scheduler.domain.SchedulerSystem;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-scheduler/log")
 public class ExecutionLogResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String latest() {
+    public JsonElement latest() {
         accessControl(Group.managers());
         return view(SchedulerSystem.getLogRepository().latest());
     }
@@ -27,7 +29,7 @@ public class ExecutionLogResource extends BennuRestResource {
     @GET
     @Path("{taskName}")
     @Produces(MediaType.APPLICATION_JSON)
-    public String executionsFor(@PathParam("taskName") String taskName, @QueryParam("count") @DefaultValue("20") int max) {
+    public JsonElement executionsFor(@PathParam("taskName") String taskName, @QueryParam("count") @DefaultValue("20") int max) {
         accessControl(Group.managers());
         return view(SchedulerSystem.getLogRepository().executionsFor(taskName, max));
     }
@@ -35,29 +37,28 @@ public class ExecutionLogResource extends BennuRestResource {
     @GET
     @Path("{taskName}/{id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response executionLog(@PathParam("taskName") String taskName, @PathParam("id") String id) {
+    public JsonElement executionLog(@PathParam("taskName") String taskName, @PathParam("id") String id) {
         accessControl(Group.managers());
-        return SchedulerSystem.getLogRepository().getLog(taskName, id).map(log -> Response.ok(view(log)).build())
-                .orElseGet(() -> Response.status(Status.NOT_FOUND).build());
+        return SchedulerSystem.getLogRepository().getLog(taskName, id).map(this::view)
+                .orElseThrow(() -> new WebApplicationException(Status.NOT_FOUND));
     }
 
     @GET
     @Path("cat/{taskName}/{id}")
     @Produces(MediaType.TEXT_PLAIN)
-    public Response taskLog(@PathParam("taskName") String taskName, @PathParam("id") String id) {
+    public String taskLog(@PathParam("taskName") String taskName, @PathParam("id") String id) {
         accessControl(Group.managers());
-        return SchedulerSystem.getLogRepository().getTaskLog(taskName, id).map(log -> Response.ok(log).build())
-                .orElseGet(() -> Response.status(Status.NOT_FOUND).build());
+        return SchedulerSystem.getLogRepository().getTaskLog(taskName, id)
+                .orElseThrow(() -> new WebApplicationException(Status.NOT_FOUND));
     }
 
     @GET
     @Path("{taskName}/{id}/{fileName}")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
-    public Response downloadFile(@PathParam("taskName") String taskName, @PathParam("id") String id,
+    public byte[] downloadFile(@PathParam("taskName") String taskName, @PathParam("id") String id,
             @PathParam("fileName") String fileName) {
         accessControl(Group.managers());
-        return SchedulerSystem.getLogRepository().getFile(taskName, id, fileName).map(file -> Response.ok(file).build())
-                .orElseGet(() -> Response.status(Status.NOT_FOUND).build());
+        return SchedulerSystem.getLogRepository().getFile(taskName, id, fileName)
+                .orElseThrow(() -> new WebApplicationException(Status.NOT_FOUND));
     }
-
 }

--- a/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/ScheduleResource.java
+++ b/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/ScheduleResource.java
@@ -11,7 +11,6 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.rest.BennuRestResource;
@@ -25,14 +24,13 @@ import pt.ist.fenixframework.Atomic.TxMode;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 @Path("/bennu-scheduler/schedule")
 public class ScheduleResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getSchedule() {
+    public JsonElement getSchedule() {
         accessControl(Group.managers());
         return view(SchedulerSystem.getInstance().getTaskScheduleSet(), "schedule");
     }
@@ -52,24 +50,24 @@ public class ScheduleResource extends BennuRestResource {
     public Response delete() {
         accessControl(Group.managers());
         clearAllSchedules();
-        return Response.ok().build();
+        return ok();
     }
 
     @POST
     @Deprecated
     @Path("dump")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    public Response loadDump(@FormParam("data") String json) {
+    public Response loadDump(@FormParam("data") JsonObject json) {
         accessControl(Group.managers());
         clearAllSchedules();
         createSchedulesFromDump(json);
-        return Response.ok().build();
+        return ok();
     }
 
     @POST
     @Path("load-dump")
     @Consumes(MediaType.APPLICATION_JSON)
-    public String loadDumpNew(String json) {
+    public JsonElement loadDumpNew(JsonObject json) {
         accessControl(Group.managers());
         clearAllSchedules();
         createSchedulesFromDump(json);
@@ -77,10 +75,9 @@ public class ScheduleResource extends BennuRestResource {
     }
 
     @Atomic(mode = TxMode.WRITE)
-    public void createSchedulesFromDump(String json) {
+    public void createSchedulesFromDump(JsonObject json) {
         TaskScheduleJsonAdapter taskScheduleJsonAdapter = new TaskScheduleJsonAdapter();
-        final JsonObject dump = new JsonParser().parse(json).getAsJsonObject();
-        for (JsonElement schedule : dump.get("schedule").getAsJsonArray()) {
+        for (JsonElement schedule : json.get("schedule").getAsJsonArray()) {
             taskScheduleJsonAdapter.create(schedule, null);
         }
     }
@@ -95,7 +92,7 @@ public class ScheduleResource extends BennuRestResource {
     @GET
     @Path("{oid}")
     @Produces(MediaType.APPLICATION_JSON)
-    public String get(@PathParam("oid") String taskOid) {
+    public JsonElement get(@PathParam("oid") String taskOid) {
         accessControl(Group.managers());
         return view(readDomainObject(taskOid));
     }
@@ -103,7 +100,7 @@ public class ScheduleResource extends BennuRestResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String addSchedule(String configJson) {
+    public JsonElement addSchedule(JsonElement configJson) {
         accessControl(Group.managers());
         return view(create(configJson, TaskSchedule.class));
     }
@@ -112,7 +109,7 @@ public class ScheduleResource extends BennuRestResource {
     @Path("{oid}")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public String changeSchedule(String taskScheduleJson, @PathParam("oid") String taskScheduleOid) {
+    public JsonElement changeSchedule(JsonElement taskScheduleJson, @PathParam("oid") String taskScheduleOid) {
         accessControl(Group.managers());
         return view(update(taskScheduleJson, readDomainObject(taskScheduleOid)));
     }
@@ -123,7 +120,7 @@ public class ScheduleResource extends BennuRestResource {
         accessControl(Group.managers());
         TaskSchedule schedule = readDomainObject(taskOid);
         schedule.delete();
-        return Response.status(Status.OK).build();
+        return ok();
     }
 
 }

--- a/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/SchedulerConfigResource.java
+++ b/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/SchedulerConfigResource.java
@@ -15,12 +15,14 @@ import org.fenixedu.bennu.scheduler.domain.SchedulerSystem;
 import pt.ist.fenixframework.Atomic;
 import pt.ist.fenixframework.Atomic.TxMode;
 
+import com.google.gson.JsonElement;
+
 @Path("/bennu-scheduler/config")
 public class SchedulerConfigResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getLoggingStorage() {
+    public JsonElement getLoggingStorage() {
         accessControl(Group.managers());
         return view(SchedulerSystem.getInstance());
     }
@@ -28,7 +30,7 @@ public class SchedulerConfigResource extends BennuRestResource {
     @PUT
     @Path("/{oid}")
     @Produces(MediaType.APPLICATION_JSON)
-    public String changeLoggingStorage(@PathParam("oid") String loggingStorageExternalId) {
+    public JsonElement changeLoggingStorage(@PathParam("oid") String loggingStorageExternalId) {
         accessControl(Group.managers());
         innerSetLoggingStorage(loggingStorageExternalId);
         return getLoggingStorage();

--- a/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/TaskResource.java
+++ b/server/bennu-scheduler/src/main/java/org/fenixedu/bennu/scheduler/rest/TaskResource.java
@@ -29,7 +29,7 @@ public class TaskResource extends BennuRestResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public String getTasks() {
+    public JsonObject getTasks() {
         accessControl(Group.managers());
         final JsonObject objContainer = new JsonObject();
         final JsonArray tasks = new JsonArray();
@@ -40,7 +40,7 @@ public class TaskResource extends BennuRestResource {
             tasks.add(taskJson);
         }
         objContainer.add("tasks", tasks);
-        return toJson(objContainer);
+        return objContainer;
     }
 
     @POST
@@ -53,7 +53,7 @@ public class TaskResource extends BennuRestResource {
         } catch (Exception e) {
             throw new WebApplicationException(Status.BAD_REQUEST);
         }
-        return Response.status(Status.OK).build();
+        return ok();
     }
 
     @Atomic(mode = TxMode.WRITE)


### PR DESCRIPTION
When using MediaType application/json in jaxrs resources, a String was
used when the JsonElement could be used directly.

The marshalling and unmarshalling is accomplished by the correspondent
providers

Json body reader and writer should dependend exclusively of the
MediaType instead of the concrete Json types.

Issues: BNN-146 BNN-147