### PR TITLE
Remove Expires header for static resources

### DIFF
--- a/bennu-portal/src/main/java/org/fenixedu/bennu/portal/rest/PortalConfigurationResource.java
+++ b/bennu-portal/src/main/java/org/fenixedu/bennu/portal/rest/PortalConfigurationResource.java
@@ -16,7 +16,6 @@ import javax.ws.rs.core.Response.Status;
 import org.fenixedu.bennu.core.groups.Group;
 import org.fenixedu.bennu.core.rest.BennuRestResource;
 import org.fenixedu.bennu.portal.domain.PortalConfiguration;
-import org.joda.time.DateTime;
 
 @Path("/bennu-portal/configuration")
 public class PortalConfigurationResource extends BennuRestResource {
@@ -39,8 +38,7 @@ public class PortalConfigurationResource extends BennuRestResource {
             if (etag.toString().equals(ifNoneMatch)) {
                 return Response.notModified(etag).build();
             }
-            return Response.ok(instance.getLogo(), instance.getLogoType()).cacheControl(CACHE_CONTROL)
-                    .expires(DateTime.now().plusHours(12).toDate()).tag(etag).build();
+            return Response.ok(instance.getLogo(), instance.getLogoType()).cacheControl(CACHE_CONTROL).tag(etag).build();
         }
         return Response.status(Status.NOT_FOUND).build();
     }
@@ -54,8 +52,7 @@ public class PortalConfigurationResource extends BennuRestResource {
     public Response favicon() {
         final PortalConfiguration instance = PortalConfiguration.getInstance();
         if (instance != null && instance.getFavicon() != null) {
-            return Response.ok(instance.getFavicon(), instance.getFaviconType()).cacheControl(CACHE_CONTROL)
-                    .expires(DateTime.now().plusHours(12).toDate()).build();
+            return Response.ok(instance.getFavicon(), instance.getFaviconType()).cacheControl(CACHE_CONTROL).build();
         }
         return Response.status(Status.NOT_FOUND).build();
     }

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/filters/StaticCacheFilter.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/filters/StaticCacheFilter.java
@@ -11,10 +11,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletResponse;
 
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
-
 /**
  * Filter that adds caching headers to static resources.
  * 
@@ -26,8 +22,6 @@ import org.joda.time.format.DateTimeFormatter;
 @WebFilter(urlPatterns = { "*.css", "*.js", "*.gif", "*.png", "*.jpg", "*.jpeg", "*.woff", "*.svg" })
 public class StaticCacheFilter implements Filter {
 
-    private final DateTimeFormatter formatter = DateTimeFormat.forPattern("E, d MMM yyyy HH:mm:ss z");
-
     @Override
     public void init(final FilterConfig filterConfig) throws ServletException {
     }
@@ -36,7 +30,6 @@ public class StaticCacheFilter implements Filter {
     public void doFilter(final ServletRequest request, final ServletResponse response, final FilterChain chain)
             throws IOException, ServletException {
         final HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-        httpServletResponse.setHeader("Expires", formatter.print(DateTime.now().plusHours(12)));
         httpServletResponse.setHeader("Cache-Control", "max-age=43200");
         chain.doFilter(request, response);
     }

--- a/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/ProfileResource.java
+++ b/server/bennu-core/src/main/java/org/fenixedu/bennu/core/rest/ProfileResource.java
@@ -33,7 +33,6 @@ import org.fenixedu.bennu.core.json.adapters.AuthenticatedUserViewer;
 import org.fenixedu.bennu.core.security.Authenticate;
 import org.fenixedu.bennu.core.util.CoreConfiguration;
 import org.fenixedu.commons.i18n.I18N;
-import org.joda.time.DateTime;
 
 import pt.ist.fenixframework.Atomic;
 import pt.ist.fenixframework.Atomic.TxMode;
@@ -140,13 +139,12 @@ public class ProfileResource extends BennuRestResource {
                 return Response.notModified(etag).build();
             }
             if (avatar != null) {
-                return Response.ok(avatar.getData(size), avatar.getMimeType()).cacheControl(CACHE_CONTROL)
-                        .expires(DateTime.now().plusHours(12).toDate()).tag(etag).build();
+                return Response.ok(avatar.getData(size), avatar.getMimeType()).cacheControl(CACHE_CONTROL).tag(etag).build();
             } else {
                 try (InputStream mm =
                         ProfileResource.class.getClassLoader().getResourceAsStream("META-INF/resources/img/mysteryman.png")) {
-                    return Response.ok(Avatar.process(mm, "image/png", size), "image/png").cacheControl(CACHE_CONTROL)
-                            .expires(DateTime.now().plusHours(12).toDate()).tag(etag).build();
+                    return Response.ok(Avatar.process(mm, "image/png", size), "image/png").cacheControl(CACHE_CONTROL).tag(etag)
+                            .build();
                 } catch (IOException e) {
                     throw BennuCoreDomainException.resourceNotFound(username);
                 }


### PR DESCRIPTION
  * On any modern browser, the Cache-Control header is used instead,
    so this one may be safely removed
  * Issue: BNN-254