### PR TITLE
Peek and add users to cache BNN-317 #resolve

### DIFF
--- a/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/User.java
+++ b/bennu-core/src/main/java/org/fenixedu/bennu/core/domain/User.java
@@ -267,8 +267,13 @@ public final class User extends User_Base implements Principal {
     }
 
     private static User manualFind(String username) {
-        return Bennu.getInstance().getUserSet().stream().filter(user -> user.getUsername().equals(username)).findAny()
+        return Bennu.getInstance().getUserSet().stream().peek(User::cacheUser)
+                .filter(user -> user.getUsername().equals(username)).findAny()
                 .orElse(null);
+    }
+
+    private static void cacheUser(User user) {
+        map.put(user.getUsername(), user);
     }
 
     public static void setUsernameGenerator(UsernameGenerator generator) {


### PR DESCRIPTION
When a user is not in the cache the user set is traversed until a match is found and that user is added to the cache. Now, all users that are traversed before a match are also added to the cache.