### PR TITLE
Fixed Default Theme's ClassCastException (BNN-375)

### DIFF
--- a/default-theme/src/main/webapp/themes/default/default.html
+++ b/default-theme/src/main/webapp/themes/default/default.html
@@ -60,9 +60,9 @@
 								<ul class="dropdown-menu">
 								  	{% for locale in locales %}
 									{% if locale == currentLocale %}
-									<li class="disabled" ><a href="#">{{ i18n('resources.DefaultThemeResources', locale) }}</a></li>
+									<li class="disabled" ><a href="#">{{ i18n('resources.DefaultThemeResources', locale.toString()) }}</a></li>
 									{% else %}
-									<li><a onclick="setLang('{{locale}}')">{{ i18n('resources.DefaultThemeResources', locale) }}</a></li>
+									<li><a onclick="setLang('{{locale}}')">{{ i18n('resources.DefaultThemeResources', locale.toString()) }}</a></li>
 									{% endif %}
 							 		{% endfor %}
 							 		<li><a href="{{contextPath}}/logout">{{ i18n('resources.DefaultThemeResources', 'label.logout') }}</a></li>


### PR DESCRIPTION
Default Theme was violating i18n function's agreed signature by passing a Locale rather than a String in its second argument, causing a ClassCastException and making the theme unusable.
This has now been fixed by calling the Locale's toString().