### PR TITLE
Allow responding conflict http errors with body message. #resolve BNN-416

### DIFF
--- a/bennu-spring/src/main/java/org/fenixedu/bennu/spring/BaseController.java
+++ b/bennu-spring/src/main/java/org/fenixedu/bennu/spring/BaseController.java
@@ -105,7 +105,14 @@ public class BaseController {
     }
 
     public static ResponseEntity<?> respondConflict() {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        return respondConflict(null);
+    }
+
+    public static ResponseEntity<?> respondConflict(final String message) {
+        if (Strings.isNullOrEmpty(message)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(message);
     }
 
     public static void setCookie(final HttpServletRequest httpRequest, final HttpServletResponse httpResponse,


### PR DESCRIPTION
The bennu-spring BaseController class contains a method to respond a ResponseEntity with http status 409 (Conflict) but this method does not allow body message as parameter.

This should be allowed, since this type of error should always let the client understand why it has a conflict.
Source: https://httpstatuses.com/409

> The server SHOULD generate a payload that includes enough information for a user to recognize the source of the conflict.
